### PR TITLE
publish: 1.6.2-migaku

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="left">Firebase Kotlin SDK <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/gitliveapp/firebase-kotlin-sdk?style=flat-square"> <a href="https://git.live"><img src="https://img.shields.io/badge/collaborate-on%20gitlive-blueviolet?style=flat-square"></a></h1>
+<h1 align="left">Firebase Kotlin SDK (for Migaku)<img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/gitliveapp/firebase-kotlin-sdk?style=flat-square"> <a href="https://git.live"><img src="https://img.shields.io/badge/collaborate-on%20gitlive-blueviolet?style=flat-square"></a></h1>
 <img align="left" width="75px" src="https://avatars2.githubusercontent.com/u/42865805?s=200&v=4"> 
   <b>Built and maintained with 🧡 by <a href="https://git.live">GitLive</a></b><br/>
   <i>Real-time code collaboration inside any IDE</i><br/>
@@ -12,14 +12,14 @@ The following libraries are available for the various Firebase products.
 
 | Service or Product	                                                             | Gradle Dependency                                                                                                            | API Coverage                                                                                                                                                             |
 |---------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Authentication](https://firebase.google.com/docs/auth)                         | [`dev.gitlive:firebase-auth:1.6.2`](https://search.maven.org/artifact/dev.gitlive/firebase-auth/1.6.2/pom)                   | [![80%](https://img.shields.io/badge/-80%25-green?style=flat-square)](/firebase-auth/src/commonMain/kotlin/dev/gitlive/firebase/auth/auth.kt)                            |
-| [Realtime Database](https://firebase.google.com/docs/database)                  | [`dev.gitlive:firebase-database:1.6.2`](https://search.maven.org/artifact/dev.gitlive/firebase-database/1.6.2/pom)           | [![70%](https://img.shields.io/badge/-70%25-orange?style=flat-square)](/firebase-database/src/commonMain/kotlin/dev/gitlive/firebase/database/database.kt)               |
-| [Cloud Firestore](https://firebase.google.com/docs/firestore)                   | [`dev.gitlive:firebase-firestore:1.6.2`](https://search.maven.org/artifact/dev.gitlive/firebase-firestore/1.6.2/pom)         | [![60%](https://img.shields.io/badge/-60%25-orange?style=flat-square)](/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt)            |
-| [Cloud Functions](https://firebase.google.com/docs/functions)                   | [`dev.gitlive:firebase-functions:1.6.2`](https://search.maven.org/artifact/dev.gitlive/firebase-functions/1.6.2/pom)         | [![80%](https://img.shields.io/badge/-80%25-green?style=flat-square)](/firebase-functions/src/commonMain/kotlin/dev/gitlive/firebase/functions/functions.kt)             |
-| [Cloud Messaging](https://firebase.google.com/docs/cloud-messaging)             | [`dev.gitlive:firebase-messaging:1.6.2`](https://search.maven.org/artifact/dev.gitlive/firebase-messaging/1.6.2/pom)         | ![0%](https://img.shields.io/badge/-0%25-lightgrey?style=flat-square)                                                                                                    |
-| [Cloud Storage](https://firebase.google.com/docs/storage)                       | [`dev.gitlive:firebase-storage:1.6.2`](https://search.maven.org/artifact/dev.gitlive/firebase-storage/1.6.2/pom)             | ![0%](https://img.shields.io/badge/-0%25-lightgrey?style=flat-square)                                                                                                    |
-| [Installations](https://firebase.google.com/docs/projects/manage-installations) | [`dev.gitlive:firebase-installations:1.6.2`](https://search.maven.org/artifact/dev.gitlive/firebase-installations/1.6.2/pom) | [![90%](https://img.shields.io/badge/-90%25-green?style=flat-square)](/firebase-installations/src/commonMain/kotlin/dev/gitlive/firebase/installations/installations.kt) |
-| [Remote Config](https://firebase.google.com/docs/remote-config)                 | [`dev.gitlive:firebase-config:1.6.2`](https://search.maven.org/artifact/dev.gitlive/firebase-config/1.6.2/pom)               | ![20%](https://img.shields.io/badge/-20%25-orange?style=flat-square)                                                                                                     |
+| [Authentication](https://firebase.google.com/docs/auth)                         | [`dev.gitlive:firebase-auth:1.6.2-migaku`](https://github.com/migaku-official/firebase-kotlin-sdk/packages/1781113)                   | [![80%](https://img.shields.io/badge/-80%25-green?style=flat-square)](/firebase-auth/src/commonMain/kotlin/dev/gitlive/firebase/auth/auth.kt)                            |
+| [Realtime Database](https://firebase.google.com/docs/database)                  | [`dev.gitlive:firebase-database:1.6.2-migaku`](https://github.com/migaku-official/firebase-kotlin-sdk/packages/1781114)           | [![70%](https://img.shields.io/badge/-70%25-orange?style=flat-square)](/firebase-database/src/commonMain/kotlin/dev/gitlive/firebase/database/database.kt)               |
+| [Cloud Firestore](https://firebase.google.com/docs/firestore)                   | [`dev.gitlive:firebase-firestore:1.6.2-migaku`](https://github.com/migaku-official/firebase-kotlin-sdk/packages/1781111)         | [![60%](https://img.shields.io/badge/-60%25-orange?style=flat-square)](/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt)            |
+| [Cloud Functions](https://firebase.google.com/docs/functions)                   | [`dev.gitlive:firebase-functions:1.6.2-migaku`](https://github.com/migaku-official/firebase-kotlin-sdk/packages/1781112)         | [![80%](https://img.shields.io/badge/-80%25-green?style=flat-square)](/firebase-functions/src/commonMain/kotlin/dev/gitlive/firebase/functions/functions.kt)             |
+| [Cloud Messaging](https://firebase.google.com/docs/cloud-messaging)             | [`dev.gitlive:firebase-messaging:1.6.2-migaku`](https://search.maven.org/artifact/dev.gitlive/firebase-messaging/1.6.2/pom)         | ![0%](https://img.shields.io/badge/-0%25-lightgrey?style=flat-square)                                                                                                    |
+| [Cloud Storage](https://firebase.google.com/docs/storage)                       | [`dev.gitlive:firebase-storage:1.6.2-migaku`](https://search.maven.org/artifact/dev.gitlive/firebase-storage/1.6.2/pom)             | ![0%](https://img.shields.io/badge/-0%25-lightgrey?style=flat-square)                                                                                                    |
+| [Installations](https://firebase.google.com/docs/projects/manage-installations) | [`dev.gitlive:firebase-installations:1.6.2-migaku`](https://github.com/migaku-official/firebase-kotlin-sdk/packages/1781110) | [![90%](https://img.shields.io/badge/-90%25-green?style=flat-square)](/firebase-installations/src/commonMain/kotlin/dev/gitlive/firebase/installations/installations.kt) |
+| [Remote Config](https://firebase.google.com/docs/remote-config)                 | [`dev.gitlive:firebase-config:1.6.2-migaku`](https://github.com/migaku-official/firebase-kotlin-sdk/packages/1781109)               | ![20%](https://img.shields.io/badge/-20%25-orange?style=flat-square)                                                                                                     |
 
 
 
@@ -201,15 +201,23 @@ If you are building a Kotlin multiplatform library which will be consumed from J
 
 ```json
 "dependencies": {
-  "@gitlive/firebase-auth": "1.6.2",
-  "@gitlive/firebase-config": "1.6.2",
-  "@gitlive/firebase-database": "1.6.2",
-  "@gitlive/firebase-firestore": "1.6.2",
-  "@gitlive/firebase-functions": "1.6.2",
-  "@gitlive/firebase-installations": "1.6.2",
-  "@gitlive/firebase-messaging": "1.6.2",
-  "@gitlive/firebase-storage": "1.6.2"
+  "@gitlive/firebase-auth": "1.6.2-migaku",
+  "@gitlive/firebase-config": "1.6.2-migaku",
+  "@gitlive/firebase-database": "1.6.2-migaku",
+  "@gitlive/firebase-firestore": "1.6.2-migaku",
+  "@gitlive/firebase-functions": "1.6.2-migaku",
+  "@gitlive/firebase-installations": "1.6.2-migaku",
+  "@gitlive/firebase-messaging": "1.6.2-migaku",
+  "@gitlive/firebase-storage": "1.6.2-migaku"
 }
+```
+
+### Publication
+
+If you would like to publish this Kotlin multiplatform library of this SDK, use the following command:
+
+```bash
+$ ./gradlew publishAllPublicationsToMavenrepository -PGITHUB_USER=<YOUR_GITHUB_USERNAME> -PGITHUB_TOKEN=<YOUR_GITHUB_PAT>
 ```
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,9 @@ buildscript {
 val targetSdkVersion by extra(32)
 val minSdkVersion by extra(19)
 
+val GITHUB_USER: String by project
+val GITHUB_TOKEN: String by project
+
 tasks {
     val updateVersions by registering {
         dependsOn(
@@ -222,10 +225,10 @@ subprojects {
 
         repositories {
             maven {
-                url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2")
+                url = uri("https://maven.pkg.github.com/migaku-official/firebase-kotlin-sdk")
                 credentials {
-                    username = project.findProperty("sonatypeUsername") as String? ?: System.getenv("sonatypeUsername")
-                    password = project.findProperty("sonatypePassword") as String? ?: System.getenv("sonatypePassword")
+                    username = GITHUB_USER
+                    password = GITHUB_TOKEN
                 }
             }
         }

--- a/firebase-app/build.gradle.kts
+++ b/firebase-app/build.gradle.kts
@@ -162,5 +162,5 @@ signing {
     val signingKey: String? by project
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications)
+//    sign(publishing.publications)
 }

--- a/firebase-app/package.json
+++ b/firebase-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitlive/firebase-app",
-  "version": "1.6.2",
+  "version": "1.6.2-migaku",
   "description": "Wrapper around firebase for usage in Kotlin Multiplatform projects",
   "main": "firebase-app.js",
   "scripts": {
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/GitLiveApp/firebase-kotlin-sdk",
   "dependencies": {
-    "@gitlive/firebase-common": "1.6.2",
+    "@gitlive/firebase-common": "1.6.2-migaku",
     "firebase": "9.7.0",
     "kotlin": "1.6.10",
     "kotlinx-coroutines-core": "1.6.1-native-mt"

--- a/firebase-auth/build.gradle.kts
+++ b/firebase-auth/build.gradle.kts
@@ -193,5 +193,5 @@ signing {
     val signingKey: String? by project
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications)
+//    sign(publishing.publications)
 }

--- a/firebase-auth/package.json
+++ b/firebase-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitlive/firebase-auth",
-  "version": "1.6.2",
+  "version": "1.6.2-migaku",
   "description": "Wrapper around firebase for usage in Kotlin Multiplatform projects",
   "main": "firebase-auth.js",
   "scripts": {
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/GitLiveApp/firebase-kotlin-sdk",
   "dependencies": {
-    "@gitlive/firebase-app": "1.6.2",
+    "@gitlive/firebase-app": "1.6.2-migaku",
     "firebase": "9.7.0",
     "kotlin": "1.6.10",
     "kotlinx-coroutines-core": "1.6.1-native-mt"

--- a/firebase-common/build.gradle.kts
+++ b/firebase-common/build.gradle.kts
@@ -124,6 +124,6 @@ signing {
     val signingKey: String? by project
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications)
+//    sign(publishing.publications)
 }
 

--- a/firebase-common/package.json
+++ b/firebase-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitlive/firebase-common",
-  "version": "1.6.2",
+  "version": "1.6.2-migaku",
   "description": "Wrapper around firebase for usage in Kotlin Multiplatform projects",
   "main": "firebase-common.js",
   "scripts": {

--- a/firebase-config/build.gradle.kts
+++ b/firebase-config/build.gradle.kts
@@ -171,5 +171,5 @@ signing {
     val signingKey: String? by project
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications)
+//    sign(publishing.publications)
 }

--- a/firebase-config/package.json
+++ b/firebase-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitlive/firebase-config",
-  "version": "1.6.2",
+  "version": "1.6.2-migaku",
   "description": "Wrapper around firebase for usage in Kotlin Multiplatform projects",
   "main": "firebase-config.js",
   "scripts": {
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/GitLiveApp/firebase-kotlin-sdk",
   "dependencies": {
-    "@gitlive/firebase-app": "1.6.2",
+    "@gitlive/firebase-app": "1.6.2-migaku",
     "firebase": "9.7.0",
     "kotlin": "1.6.10",
     "kotlinx-coroutines-core": "1.6.1-native-mt"

--- a/firebase-database/build.gradle.kts
+++ b/firebase-database/build.gradle.kts
@@ -178,6 +178,6 @@ signing {
     val signingKey: String? by project
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications)
+//    sign(publishing.publications)
 }
 

--- a/firebase-database/package.json
+++ b/firebase-database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitlive/firebase-database",
-  "version": "1.6.2",
+  "version": "1.6.2-migaku",
   "description": "Wrapper around firebase for usage in Kotlin Multiplatform projects",
   "main": "firebase-database.js",
   "scripts": {
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/GitLiveApp/firebase-kotlin-sdk",
   "dependencies": {
-    "@gitlive/firebase-app": "1.6.2",
+    "@gitlive/firebase-app": "1.6.2-migaku",
     "firebase": "9.7.0",
     "kotlin": "1.6.10",
     "kotlinx-coroutines-core": "1.6.1-native-mt"

--- a/firebase-firestore/build.gradle.kts
+++ b/firebase-firestore/build.gradle.kts
@@ -177,5 +177,5 @@ signing {
     val signingKey: String? by project
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications)
+//    sign(publishing.publications)
 }

--- a/firebase-firestore/package.json
+++ b/firebase-firestore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitlive/firebase-firestore",
-  "version": "1.6.2",
+  "version": "1.6.2-migaku",
   "description": "Wrapper around firebase for usage in Kotlin Multiplatform projects",
   "main": "firebase-firestore.js",
   "scripts": {
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/GitLiveApp/firebase-kotlin-sdk",
   "dependencies": {
-    "@gitlive/firebase-app": "1.6.2",
+    "@gitlive/firebase-app": "1.6.2-migaku",
     "firebase": "9.7.0",
     "kotlin": "1.6.10",
     "kotlinx-coroutines-core": "1.6.1-native-mt"

--- a/firebase-functions/build.gradle.kts
+++ b/firebase-functions/build.gradle.kts
@@ -165,5 +165,5 @@ signing {
     val signingKey: String? by project
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications)
+//    sign(publishing.publications)
 }

--- a/firebase-functions/package.json
+++ b/firebase-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitlive/firebase-functions",
-  "version": "1.6.2",
+  "version": "1.6.2-migaku",
   "description": "Wrapper around firebase for usage in Kotlin Multiplatform projects",
   "main": "firebase-functions.js",
   "scripts": {
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/GitLiveApp/firebase-kotlin-sdk",
   "dependencies": {
-    "@gitlive/firebase-app": "1.6.2",
+    "@gitlive/firebase-app": "1.6.2-migaku",
     "firebase": "9.7.0",
     "kotlin": "1.6.10",
     "kotlinx-coroutines-core": "1.6.1-native-mt"

--- a/firebase-installations/build.gradle.kts
+++ b/firebase-installations/build.gradle.kts
@@ -156,5 +156,5 @@ signing {
     val signingKey: String? by project
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications)
+//    sign(publishing.publications)
 }

--- a/firebase-installations/package.json
+++ b/firebase-installations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitlive/firebase-installations",
-  "version": "1.6.2",
+  "version": "1.6.2-migaku",
   "description": "Wrapper around firebase for usage in Kotlin Multiplatform projects",
   "main": "firebase-installations.js",
   "scripts": {
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/GitLiveApp/firebase-kotlin-sdk",
   "dependencies": {
-    "@gitlive/firebase-app": "1.6.2",
+    "@gitlive/firebase-app": "1.6.2-migaku",
     "firebase": "9.7.0",
     "kotlin": "1.6.10",
     "kotlinx-coroutines-core": "1.6.1-native-mt"

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,11 +31,11 @@ firebase-functions.skipIosTests=false
 firebase-installations.skipIosTests=false
 
 # Versions:
-firebase-app.version=1.6.2
-firebase-auth.version=1.6.2
-firebase-common.version=1.6.2
-firebase-config.version=1.6.2
-firebase-database.version=1.6.2
-firebase-firestore.version=1.6.2
-firebase-functions.version=1.6.2
-firebase-installations.version=1.6.2
+firebase-app.version=1.6.2-migaku
+firebase-auth.version=1.6.2-migaku
+firebase-common.version=1.6.2-migaku
+firebase-config.version=1.6.2-migaku
+firebase-database.version=1.6.2-migaku
+firebase-firestore.version=1.6.2-migaku
+firebase-functions.version=1.6.2-migaku
+firebase-installations.version=1.6.2-migaku


### PR DESCRIPTION
### Changes:
- Able to publish `migaku` version Kotlin Multiplatform libraries of this SDK on Github Packages.